### PR TITLE
Changes for OCF 1.0 CR-1416: Error code support

### DIFF
--- a/oic.r.pstat.raml
+++ b/oic.r.pstat.raml
@@ -129,10 +129,13 @@ traits:
             example: |
               DELETE /mypstat?deviceid="de305d54-75b4-431b-adb2-eb6b9e546014"
     responses:
-      200:
-        description: The PSTAT instance or the the entire resource has been successfully deleted.
+      201:
+        description: The PSTAT entry is created.
       400:
-        description: The request is invalid.
+      401:
+      403:
+      422:
+        description: There was an error deleting the resource.
         body:
           application/json:
             schema: Error

--- a/oic.r.pstat.raml
+++ b/oic.r.pstat.raml
@@ -3,6 +3,7 @@ title: OICSecurityPstatResource
 version: v1.0-20150819
 schemas:
   - Pstat: !include schemas/oic.r.pstat.json
+  - Error: !include schemas/oic.sec.error.json
 
 traits:
   - interface:
@@ -77,6 +78,9 @@ traits:
         description: The PSTAT entry is updated.
       400:
         description: The request is invalid.
+        body:
+          application/json:
+            schema: Error
 
   put:
     description: |
@@ -107,6 +111,9 @@ traits:
         description: The PSTAT entry is created.
       400:
         description: The request is invalid.
+        body:
+          application/json:
+            schema: Error
 
   delete:
     description: |
@@ -126,3 +133,6 @@ traits:
         description: The PSTAT instance or the the entire resource has been successfully deleted.
       400:
         description: The request is invalid.
+        body:
+          application/json:
+            schema: Error

--- a/schemas/oic.sec.error.json
+++ b/schemas/oic.sec.error.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://www.openconnectivity.org/ocf-apis/security/schemas/oic.sec.error.json#",
+  "title": "Provides error details for security operations",
+  "definitions": {
+    "oic.sec.error": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "description": "The error code value"
+        },
+        "message": {
+          "type": "string",
+          "description": "String array represents a recurrence rule using the RFC5545 Recurrence",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [ "period" ]
+    }
+  }
+}

--- a/schemas/oic.sec.error.json
+++ b/schemas/oic.sec.error.json
@@ -18,7 +18,7 @@
           }
         }
       },
-      "required": [ "period" ]
+      "required": [ "code" ]
     }
   }
 }


### PR DESCRIPTION
This CR defines an error code reporting object for OCF Security resources. It also defines transport-independent error pnumonics and codes and a mapping of the transport-independant error codes to HTTP and CoAP result codes.

The error code reporting defined in this CR is a common REST error reporting pattern. And the HTTP/CoAP-specific status code mappings are defined to be consistent with commonly-accepted error classifications for REST APIs.
