### PR TITLE
[Bug 3101] Adding "oic.if.rw" to all SVRs

### DIFF
--- a/swagger2.0/oic.sec.acl2.swagger.json
+++ b/swagger2.0/oic.sec.acl2.swagger.json
@@ -175,7 +175,7 @@
       "in" : "query",
       "name" : "if",
       "type" : "string",
-      "enum" : ["oic.if.baseline"]
+      "enum" : [ "oic.if.baseline", "oic.if.rw" ]
     },
     "ace-filtered" : {
       "in" : "query",
@@ -349,9 +349,7 @@
         "if" : {
           "description": "The interface set supported by this Resource.",
           "items": {
-            "enum": [
-              "oic.if.baseline"
-            ],
+            "enum": [ "oic.if.baseline", "oic.if.rw" ],
             "type": "string"
           },
           "minItems": 1,

--- a/swagger2.0/oic.sec.cred.swagger.json
+++ b/swagger2.0/oic.sec.cred.swagger.json
@@ -192,7 +192,7 @@
       "in" : "query",
       "name" : "if",
       "type" : "string",
-      "enum" : ["oic.if.baseline"]
+      "enum" : [ "oic.if.baseline", "oic.if.rw" ]
     },
     "cred-filtered-credid" : {
       "in" : "query",
@@ -403,9 +403,7 @@
         "if" : {
           "description": "The interface set supported by this Resource.",
           "items": {
-            "enum": [
-              "oic.if.baseline"
-            ],
+            "enum": [ "oic.if.baseline", "oic.if.rw" ],
             "type": "string"
           },
           "minItems": 1,

--- a/swagger2.0/oic.sec.csr.swagger.json
+++ b/swagger2.0/oic.sec.csr.swagger.json
@@ -46,7 +46,7 @@
       "in" : "query",
       "name" : "if",
       "type" : "string",
-      "enum" : ["oic.if.baseline"]
+      "enum" : [ "oic.if.baseline", "oic.if.rw" ]
     }
   },
   "definitions": {
@@ -89,9 +89,7 @@
         "if": {
           "description": "The interface set supported by this Resource.",
           "items": {
-            "enum": [
-              "oic.if.baseline"
-            ],
+            "enum": [ "oic.if.baseline", "oic.if.rw" ],
             "type": "string"
           },
           "minItems": 1,

--- a/swagger2.0/oic.sec.doxm.swagger.json
+++ b/swagger2.0/oic.sec.doxm.swagger.json
@@ -77,7 +77,7 @@
       "in" : "query",
       "name" : "if",
       "type" : "string",
-      "enum" : ["oic.if.baseline"]
+      "enum" : [ "oic.if.baseline", "oic.if.rw" ]
     }
   },
   "definitions": {
@@ -142,9 +142,7 @@
         "if": {
           "description": "The interface set supported by this Resource.",
           "items": {
-            "enum": [
-              "oic.if.baseline"
-            ],
+            "enum": [ "oic.if.baseline", "oic.if.rw" ],
             "type": "string"
           },
           "minItems": 1,

--- a/swagger2.0/oic.sec.pstat.swagger.json
+++ b/swagger2.0/oic.sec.pstat.swagger.json
@@ -75,7 +75,7 @@
       "in" : "query",
       "name" : "if",
       "type" : "string",
-      "enum" : ["oic.if.baseline"]
+      "enum" : [ "oic.if.baseline", "oic.if.rw" ]
     }
   },
   "definitions": {
@@ -165,9 +165,7 @@
         "if" : {
           "description": "The interface set supported by this Resource.",
           "items": {
-            "enum": [
-              "oic.if.baseline"
-            ],
+            "enum": [ "oic.if.baseline", "oic.if.rw" ],
             "type": "string"
           },
           "minItems": 1,

--- a/swagger2.0/oic.sec.roles.swagger.json
+++ b/swagger2.0/oic.sec.roles.swagger.json
@@ -60,7 +60,7 @@
                       }
                   ],
                   "rt":["oic.r.roles"],
-                  "if":["oic.if.baseline"]
+                  "if":[ "oic.if.baseline", "oic.if.rw" ]
                 }
                 ,
               "schema": { "$ref": "#/definitions/Roles" }
@@ -149,7 +149,7 @@
       "in" : "query",
       "name" : "if",
       "type" : "string",
-      "enum" : ["oic.if.baseline"]
+      "enum" : [ "oic.if.baseline", "oic.if.rw" ]
     },
     "roles-filtered" : {
       "in" : "query",
@@ -371,9 +371,7 @@
         "if": {
           "description": "The interface set supported by this Resource.",
           "items": {
-            "enum": [
-              "oic.if.baseline"
-            ],
+            "enum": [ "oic.if.baseline", "oic.if.rw" ],
             "type": "string"
           },
           "minItems": 1,

--- a/swagger2.0/oic.sec.roles.swagger.json
+++ b/swagger2.0/oic.sec.roles.swagger.json
@@ -60,7 +60,7 @@
                       }
                   ],
                   "rt":["oic.r.roles"],
-                  "if":[ "oic.if.baseline", "oic.if.rw" ]
+                  "if":[ "oic.if.rw" ]
                 }
                 ,
               "schema": { "$ref": "#/definitions/Roles" }

--- a/swagger2.0/oic.sec.sp.swagger.json
+++ b/swagger2.0/oic.sec.sp.swagger.json
@@ -75,7 +75,7 @@
       "in" : "query",
       "name" : "if",
       "type" : "string",
-      "enum" : ["oic.if.baseline"]
+      "enum" : [ "oic.if.baseline", "oic.if.rw" ]
     }
   },
   "definitions": {
@@ -112,9 +112,7 @@
         "if": {
           "description": "The interface set supported by this Resource.",
           "items": {
-            "enum": [
-              "oic.if.baseline"
-            ],
+            "enum": [ "oic.if.baseline", "oic.if.rw" ],
             "type": "string"
           },
           "minItems": 1,


### PR DESCRIPTION
It is recommended to avoid using "oic.if.baseline". Support of at least one other interface is needed.